### PR TITLE
add repository link

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "ember server",
     "test": "ember try:each"
   },
-  "repository": "",
+  "repository": "https://github.com/robneville73/ember-leaflet-mapquest-tile",
   "engines": {
     "node": ">= 0.12.0"
   },


### PR DESCRIPTION
New ember-leaflet website will auto fetch the ember-leaflet addons from npm and will use the repository link to render a link. So, this is needed for the addon to show up correctly in the list.

You might need to publish it after update package.json.